### PR TITLE
Cosmetic fixes for GL.iNet uboot-ipq40xx loader

### DIFF
--- a/uboot/arch/arm/cpu/armv7/qca/cmd_blowsecfuse.c
+++ b/uboot/arch/arm/cpu/armv7/qca/cmd_blowsecfuse.c
@@ -38,8 +38,8 @@ int do_fuseipq(cmd_tbl_t *cmdtp, int flag, int argc, char *const argv[])
 	} fuseip;
 
 	if (argc != 2) {
-		printf("No Arguments provided\n");
-		printf("Command format: fuseipq <address>\n");
+		printf("No arguments provided\n");
+		printf("Usage: fuseipq <address>\n");
 		return 1;
 	}
 
@@ -59,13 +59,13 @@ int do_fuseipq(cmd_tbl_t *cmdtp, int flag, int argc, char *const argv[])
 	else if (fuse_status == FUSEPROV_INVALID_HASH)
 		printf("Invalid sec.dat\n");
 	else if (fuse_status  != FUSEPROV_SUCCESS)
-		printf("Failed to Blow fuses");
+		printf("Failed to blow fuses");
 	else
-		printf("Blow Success\n");
+		printf("Blow succeeded\n");
 
 	return 0;
 }
 
 U_BOOT_CMD(fuseipq, 2, 0, do_fuseipq,
 		"fuse QFPROM registers from memory\n",
-		"fuseipq [address]  - Load fuse(s) and blows in the qfprom");
+		"fuseipq [address]  - Load fuse(s) and blow in the QFPROM");

--- a/uboot/arch/arm/cpu/armv7/qca/cmd_bootqca.c
+++ b/uboot/arch/arm/cpu/armv7/qca/cmd_bootqca.c
@@ -167,7 +167,7 @@ int config_select(unsigned int addr, const char **config, char *rcmd, int rcmd_s
 			return 0;
 		}
 	}
-	printf("Config not availabale\n");
+	printf("Configuration not available\n");
 	return -1;
 }
 
@@ -204,7 +204,7 @@ static int do_boot_signedimg(cmd_tbl_t *cmdtp, int flag, int argc, char *const a
 		ret = scm_call(SCM_SVC_BOOT, SCM_SVC_WR,
 			(void *)&val, sizeof(val), NULL, 0);
 		if (ret)
-			printf ("Error in reseting the Magic cookie\n");
+			printf("Failed to reset the magic cookie\n");
 
 		etime = get_timer_masked() + (10 * CONFIG_SYS_HZ);
 
@@ -239,10 +239,10 @@ static int do_boot_signedimg(cmd_tbl_t *cmdtp, int flag, int argc, char *const a
 		}
 	} else if (sfi->flash_type == SMEM_BOOT_MMC_FLASH) {
 		if (debug) {
-			printf("Using MMC device\n");
+			printf("Using mmc device\n");
 		}
 	} else {
-		printf("Unsupported BOOT flash type\n");
+		printf("Unsupported boot flash type\n");
 		return -1;
 	}
 	if (debug) {
@@ -330,7 +330,7 @@ static int do_boot_signedimg(cmd_tbl_t *cmdtp, int flag, int argc, char *const a
 		sizeof(kernel_img_info_t), NULL, 0);
 
 	if (ret) {
-		printf("Kernel image authentication failed \n");
+		printf("Kernel image authentication failed\n");
 		BUG();
 	}
 
@@ -387,7 +387,7 @@ static int do_boot_unsignedimg(cmd_tbl_t *cmdtp, int flag, int argc, char *const
 		ret = scm_call(SCM_SVC_BOOT, SCM_SVC_WR,
 			(void *)&val, sizeof(val), NULL, 0);
 		if (ret)
-			printf ("Error in reseting the Magic cookie\n");
+			printf ("Failed to reset the magic cookie\n");
 
 		etime = get_timer_masked() + (10 * CONFIG_SYS_HZ);
 
@@ -505,7 +505,7 @@ static int do_boot_unsignedimg(cmd_tbl_t *cmdtp, int flag, int argc, char *const
 
 #endif   	/* CONFIG_QCA_MMC   */
 	} else {
-		printf("Unsupported BOOT flash type\n");
+		printf("Unsupported boot flash type\n");
 		return -1;
 	}
 
@@ -577,4 +577,4 @@ static int do_bootipq(cmd_tbl_t *cmdtp, int flag, int argc, char *const argv[])
 
 U_BOOT_CMD(bootipq, 2, 0, do_bootipq,
 	   "bootipq from flash device",
-	   "bootipq [debug] - Load image(s) and boots the kernel\n");
+	   "bootipq [debug] - Load image(s) and boot the kernel\n");

--- a/uboot/arch/arm/cpu/armv7/qca/smem.c
+++ b/uboot/arch/arm/cpu/armv7/qca/smem.c
@@ -605,6 +605,6 @@ int do_smeminfo(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
 
 U_BOOT_CMD(
 	smeminfo,    1,    0,    do_smeminfo,
-	"print SMEM FLASH information",
+	"print SMEM flash information",
 	"\n    - print flash details gathered from SMEM\n"
 );

--- a/uboot/board/qcom/ipq40xx_cdp/ipq40xx_cdp.c
+++ b/uboot/board/qcom/ipq40xx_cdp/ipq40xx_cdp.c
@@ -984,7 +984,7 @@ static int ipq40xx_patch_eth_params(void *blob, unsigned long gmac_no)
 			debug("%s: unable to patch alias\n", __func__);
 		nodeoff_c = fdt_path_offset(blob, "/soc/edma");
 		if (nodeoff_c < 0) {
-			printf("ipq: unable to find compatiable edma node\n");
+			printf("ipq: unable to find compatible edma node\n");
 			return -1;
 		}
 
@@ -997,7 +997,7 @@ static int ipq40xx_patch_eth_params(void *blob, unsigned long gmac_no)
 	case 3:
 		nodeoff_c = fdt_path_offset(blob, "/soc/edma/gmac1");
 		if (nodeoff_c < 0) {
-			printf("ipq: unable to find compatiable edma node\n");
+			printf("ipq: unable to find compatible edma node\n");
 			return -1;
 		}
 		vlan.r0 = htonl(0x1);
@@ -1009,7 +1009,7 @@ static int ipq40xx_patch_eth_params(void *blob, unsigned long gmac_no)
 
 		nodeoff_c = fdt_path_offset(blob, "/soc/edma/gmac2");
 		if (nodeoff_c < 0) {
-			printf("ipq: unable to find compatiable edma node\n");
+			printf("ipq: unable to find compatible edma node\n");
 			return -1;
 		}
 		vlan.r0 = htonl(0x3);
@@ -1022,7 +1022,7 @@ static int ipq40xx_patch_eth_params(void *blob, unsigned long gmac_no)
 	case 4:
 		nodeoff_c = fdt_path_offset(blob, "/soc/edma/gmac1");
 		if (nodeoff_c < 0) {
-			printf("ipq: unable to find compatiable edma node\n");
+			printf("ipq: unable to find compatible edma node\n");
 			return -1;
 		}
 		vlan.r0 = htonl(0x1);
@@ -1034,7 +1034,7 @@ static int ipq40xx_patch_eth_params(void *blob, unsigned long gmac_no)
 
 		nodeoff_c = fdt_path_offset(blob, "/soc/edma/gmac2");
 		if (nodeoff_c < 0) {
-			printf("ipq: unable to find compatiable edma node\n");
+			printf("ipq: unable to find compatible edma node\n");
 			return -1;
 		}
 		vlan.r0 = htonl(0x3);
@@ -1046,7 +1046,7 @@ static int ipq40xx_patch_eth_params(void *blob, unsigned long gmac_no)
 
 		nodeoff_c = fdt_path_offset(blob, "/soc/edma/gmac3");
 		if (nodeoff_c < 0) {
-			printf("ipq: unable to find compatiable edma node\n");
+			printf("ipq: unable to find compatible edma node\n");
 			return -1;
 		}
 		vlan.r0 = htonl(0x4);
@@ -1059,7 +1059,7 @@ static int ipq40xx_patch_eth_params(void *blob, unsigned long gmac_no)
 	case 5:
 		nodeoff_c = fdt_path_offset(blob, "/soc/edma/gmac1");
 		if (nodeoff_c < 0) {
-			printf("ipq: unable to find compatiable edma node\n");
+			printf("ipq: unable to find compatible edma node\n");
 			return -1;
 		}
 		vlan.r0 = htonl(0x1);
@@ -1079,7 +1079,7 @@ static int ipq40xx_patch_eth_params(void *blob, unsigned long gmac_no)
 
 		nodeoff_c = fdt_path_offset(blob, "/soc/edma/gmac2");
 		if (nodeoff_c < 0) {
-			printf("ipq: unable to find compatiable edma node\n");
+			printf("ipq: unable to find compatible edma node\n");
 			return -1;
 		}
 		vlan.r0 = htonl(0x3);
@@ -1099,7 +1099,7 @@ static int ipq40xx_patch_eth_params(void *blob, unsigned long gmac_no)
 
 		nodeoff_c = fdt_path_offset(blob, "/soc/edma/gmac3");
 		if (nodeoff_c < 0) {
-			printf("ipq: unable to find compatiable edma node\n");
+			printf("ipq: unable to find compatible edma node\n");
 			return -1;
 		}
 		vlan.r0 = htonl(0x4);
@@ -1119,7 +1119,7 @@ static int ipq40xx_patch_eth_params(void *blob, unsigned long gmac_no)
 
 		nodeoff_c = fdt_path_offset(blob, "/soc/edma/gmac4");
 		if (nodeoff_c < 0) {
-			printf("ipq: unable to find compatiable edma node\n");
+			printf("ipq: unable to find compatible edma node\n");
 			return -1;
 		}
 		vlan.r0 = htonl(0x5);

--- a/uboot/common/cmd_bootm.c
+++ b/uboot/common/cmd_bootm.c
@@ -206,7 +206,7 @@ static int bootm_start(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[]
 	os_hdr = boot_get_kernel(cmdtp, flag, argc, argv,
 			&images, &images.os.image_start, &images.os.image_len);
 	if (images.os.image_len == 0) {
-		puts("ERROR: can't get kernel image!\n");
+		puts("Can't get kernel image!\n");
 		return 1;
 	}
 
@@ -254,7 +254,7 @@ static int bootm_start(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[]
 		break;
 #endif
 	default:
-		puts("ERROR: unknown image format type!\n");
+		puts("Unknown image format type!\n");
 		return 1;
 	}
 
@@ -348,8 +348,8 @@ static int bootm_load_os(image_info_t os, ulong *load_end, int boot_progress)
 		printf("   Uncompressing %s ... ", type_name);
 		if (gunzip((void *)load, unc_len,
 				(uchar *)image_start, &image_len) != 0) {
-			puts("GUNZIP: uncompress, out-of-mem or overwrite "
-				"error - must RESET board to recover\n");
+			puts("Gunzip: uncompress, out-of-mem or overwrite "
+				"error - must reset board to recover\n");
 			if (boot_progress)
 				bootstage_error(BOOTSTAGE_ID_DECOMP_IMAGE);
 			return BOOTM_ERR_RESET;
@@ -370,8 +370,8 @@ static int bootm_load_os(image_info_t os, ulong *load_end, int boot_progress)
 					&unc_len, (char *)image_start, image_len,
 					CONFIG_SYS_MALLOC_LEN < (4096 * 1024), 0);
 		if (i != BZ_OK) {
-			printf("BUNZIP2: uncompress or overwrite error %d "
-				"- must RESET board to recover\n", i);
+			printf("Bunzip2: uncompress or overwrite error %d "
+				"- must reset board to recover\n", i);
 			if (boot_progress)
 				bootstage_error(BOOTSTAGE_ID_DECOMP_IMAGE);
 			return BOOTM_ERR_RESET;
@@ -390,8 +390,8 @@ static int bootm_load_os(image_info_t os, ulong *load_end, int boot_progress)
 			(unsigned char *)image_start, image_len);
 		unc_len = lzma_len;
 		if (ret != SZ_OK) {
-			printf("LZMA: uncompress or overwrite error %d "
-				"- must RESET board to recover\n", ret);
+			printf("Lzma: uncompress or overwrite error %d "
+				"- must reset board to recover\n", ret);
 			bootstage_error(BOOTSTAGE_ID_DECOMP_IMAGE);
 			return BOOTM_ERR_RESET;
 		}
@@ -407,8 +407,8 @@ static int bootm_load_os(image_info_t os, ulong *load_end, int boot_progress)
 					  image_len, (unsigned char *)load,
 					  &unc_len);
 		if (ret != LZO_E_OK) {
-			printf("LZO: uncompress or overwrite error %d "
-			      "- must RESET board to recover\n", ret);
+			printf("Lzo: uncompress or overwrite error %d "
+			      "- must reset board to recover\n", ret);
 			if (boot_progress)
 				bootstage_error(BOOTSTAGE_ID_DECOMP_IMAGE);
 			return BOOTM_ERR_RESET;
@@ -752,9 +752,9 @@ static image_header_t *image_get_kernel(ulong img_addr, int verify)
 	image_print_contents(hdr);
 
 	if (verify) {
-		puts("   Verifying Checksum ... ");
+		puts("   Verifying checksum ... ");
 		if (!image_check_dcrc(hdr)) {
-			printf("Bad Data CRC\n");
+			printf("Bad data CRC\n");
 			bootstage_error(BOOTSTAGE_ID_CHECK_CHECKSUM);
 			return NULL;
 		}
@@ -764,7 +764,7 @@ static image_header_t *image_get_kernel(ulong img_addr, int verify)
 
 #ifndef CONFIG_IPQ_FIRMWARE
 	if (!image_check_target_arch(hdr)) {
-		printf("Unsupported Architecture 0x%x\n", image_get_arch(hdr));
+		printf("Unsupported architecture 0x%x\n", image_get_arch(hdr));
 		bootstage_error(BOOTSTAGE_ID_CHECK_ARCH);
 		return NULL;
 	}
@@ -791,9 +791,9 @@ static int fit_check_kernel(const void *fit, int os_noffset, int verify)
 	fit_image_print(fit, os_noffset, "   ");
 
 	if (verify) {
-		puts("   Verifying Hash Integrity ... ");
+		puts("   Verifying hash integrity ... ");
 		if (!fit_image_check_hashes(fit, os_noffset)) {
-			puts("Bad Data Hash\n");
+			puts("Bad data hash\n");
 			bootstage_error(BOOTSTAGE_ID_FIT_CHECK_HASH);
 			return 0;
 		}
@@ -802,7 +802,7 @@ static int fit_check_kernel(const void *fit, int os_noffset, int verify)
 	bootstage_mark(BOOTSTAGE_ID_FIT_CHECK_ARCH);
 
 	if (!fit_image_check_target_arch(fit, os_noffset)) {
-		puts("Unsupported Architecture\n");
+		puts("Unsupported architecture\n");
 		bootstage_error(BOOTSTAGE_ID_FIT_CHECK_ARCH);
 		return 0;
 	}
@@ -878,7 +878,7 @@ static void *boot_get_kernel(cmd_tbl_t *cmdtp, int flag, int argc,
 	switch (genimg_get_format((void *)img_addr)) {
 	case IMAGE_FORMAT_LEGACY:
 #ifndef CONFIG_IPQ_FIRMWARE
-		printf("## Booting kernel from Legacy Image at %08lx ...\n",
+		printf("## Booting kernel from legacy image at %08lx ...\n",
 				img_addr);
 #endif
 		hdr = image_get_kernel(img_addr, images->verify);
@@ -904,7 +904,7 @@ static void *boot_get_kernel(cmd_tbl_t *cmdtp, int flag, int argc,
 			*os_len = image_get_data_size(hdr);
 			break;
 		default:
-			printf("Wrong Image Type for %s command\n",
+			printf("Wrong image type for %s command\n",
 				cmdtp->name);
 			bootstage_error(BOOTSTAGE_ID_CHECK_IMAGETYPE);
 			return NULL;
@@ -926,7 +926,7 @@ static void *boot_get_kernel(cmd_tbl_t *cmdtp, int flag, int argc,
 #if defined(CONFIG_FIT)
 	case IMAGE_FORMAT_FIT:
 		fit_hdr = (void *)img_addr;
-		printf("## Booting kernel from FIT Image at %08lx ...\n",
+		printf("## Booting kernel from FIT image at %08lx ...\n",
 				img_addr);
 
 		if (!fit_check_format(fit_hdr)) {
@@ -997,7 +997,7 @@ static void *boot_get_kernel(cmd_tbl_t *cmdtp, int flag, int argc,
 		break;
 #endif
 	default:
-		printf("Wrong Image Format for %s command\n", cmdtp->name);
+		printf("Wrong image format for %s command\n", cmdtp->name);
 		bootstage_error(BOOTSTAGE_ID_FIT_KERNEL_INFO);
 		return NULL;
 	}
@@ -1101,26 +1101,26 @@ static int image_info(ulong addr)
 {
 	void *hdr = (void *)addr;
 
-	printf("\n## Checking Image at %08lx ...\n", addr);
+	printf("\n## Checking image at %08lx ...\n", addr);
 
 	switch (genimg_get_format(hdr)) {
 	case IMAGE_FORMAT_LEGACY:
 		puts("   Legacy image found\n");
 		if (!image_check_magic(hdr)) {
-			puts("   Bad Magic Number\n");
+			puts("   Bad magic number\n");
 			return 1;
 		}
 
 		if (!image_check_hcrc(hdr)) {
-			puts("   Bad Header Checksum\n");
+			puts("   Bad header checksum\n");
 			return 1;
 		}
 
 		image_print_contents(hdr);
 
-		puts("   Verifying Checksum ... ");
+		puts("   Verifying checksum ... ");
 		if (!image_check_dcrc(hdr)) {
-			puts("   Bad Data CRC\n");
+			puts("   Bad data CRC\n");
 			return 1;
 		}
 		puts("OK\n");
@@ -1188,12 +1188,12 @@ int do_imls(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
 				if (!image_check_hcrc(hdr))
 					goto next_sector;
 
-				printf("Legacy Image at %08lX:\n", (ulong)hdr);
+				printf("Legacy image at %08lX:\n", (ulong)hdr);
 				image_print_contents(hdr);
 
-				puts("   Verifying Checksum ... ");
+				puts("   Verifying checksum ... ");
 				if (!image_check_dcrc(hdr)) {
-					puts("Bad Data CRC\n");
+					puts("Bad data CRC\n");
 				} else {
 					puts("OK\n");
 				}
@@ -1203,7 +1203,7 @@ int do_imls(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
 				if (!fit_check_format(hdr))
 					goto next_sector;
 
-				printf("FIT Image at %08lX:\n", (ulong)hdr);
+				printf("FIT image at %08lX:\n", (ulong)hdr);
 				fit_print_contents(hdr);
 				break;
 #endif
@@ -1223,8 +1223,8 @@ U_BOOT_CMD(
 	imls,	1,		1,	do_imls,
 	"list all images found in flash",
 	"\n"
-	"    - Prints information about all images found at sector\n"
-	"      boundaries in flash."
+	"    - print information about all images found at sector\n"
+	"      boundaries in flash"
 );
 #endif
 

--- a/uboot/common/cmd_nvedit.c
+++ b/uboot/common/cmd_nvedit.c
@@ -1039,7 +1039,7 @@ U_BOOT_CMD(
 #if (defined(CONFIG_CMD_RUN))
 U_BOOT_CMD_COMPLETE(
 	run_var,	CONFIG_SYS_MAXARGS,	1,	do_run_origin,
-	"run commands in an environment variable 1",
+	"run commands in an environment variable",
 	"var [...]\n"
 	"    - run the commands in the environment variable(s) 'var'",
 	var_complete

--- a/uboot/common/cmd_ximg.c
+++ b/uboot/common/cmd_ximg.c
@@ -85,12 +85,12 @@ do_imgextract(cmd_tbl_t * cmdtp, int flag, int argc, char * const argv[])
 
 		hdr = (image_header_t *)addr;
 		if (!image_check_magic(hdr)) {
-			printf("Bad Magic Number\n");
+			printf("Bad magic number\n");
 			return 1;
 		}
 
 		if (!image_check_hcrc(hdr)) {
-			printf("Bad Header Checksum\n");
+			printf("Bad header checksum\n");
 			return 1;
 		}
 #ifdef DEBUG
@@ -98,7 +98,7 @@ do_imgextract(cmd_tbl_t * cmdtp, int flag, int argc, char * const argv[])
 #endif
 
 		if (!image_check_type(hdr, IH_TYPE_MULTI)) {
-			printf("Wrong Image Type for %s command\n",
+			printf("Wrong image type for %s command\n",
 					cmdtp->name);
 			return 1;
 		}
@@ -112,9 +112,9 @@ do_imgextract(cmd_tbl_t * cmdtp, int flag, int argc, char * const argv[])
 		}
 
 		if (verify) {
-			printf("   Verifying Checksum ... ");
+			printf("   Verifying checksum ... ");
 			if (!image_check_dcrc(hdr)) {
-				printf("Bad Data CRC\n");
+				printf("Bad data CRC\n");
 				return 1;
 			}
 			printf("OK\n");
@@ -122,7 +122,7 @@ do_imgextract(cmd_tbl_t * cmdtp, int flag, int argc, char * const argv[])
 
 		count = image_multi_count(hdr);
 		if (part >= count) {
-			printf("Bad Image Part\n");
+			printf("Bad image part\n");
 			return 1;
 		}
 
@@ -162,7 +162,7 @@ do_imgextract(cmd_tbl_t * cmdtp, int flag, int argc, char * const argv[])
 		/* verify integrity */
 		if (verify) {
 			if (!fit_image_check_hashes(fit_hdr, noffset)) {
-				puts("Bad Data Hash\n");
+				puts("Bad data hash\n");
 				return 1;
 			}
 		}
@@ -220,7 +220,7 @@ do_imgextract(cmd_tbl_t * cmdtp, int flag, int argc, char * const argv[])
 			printf("   Uncompressing part %d ... ", part);
 			if (gunzip((void *) dest, unc_len,
 				   (uchar *) data, &len) != 0) {
-				puts("GUNZIP ERROR - image not loaded\n");
+				puts("Gunzip error - image not loaded\n");
 				return 1;
 			}
 			break;
@@ -242,7 +242,7 @@ do_imgextract(cmd_tbl_t * cmdtp, int flag, int argc, char * const argv[])
 					CONFIG_SYS_MALLOC_LEN < (4096 * 1024),
 					0);
 				if (i != BZ_OK) {
-					printf("BUNZIP2 ERROR %d - "
+					printf("Bunzip error %d - "
 						"image not loaded\n", i);
 					return 1;
 				}

--- a/uboot/common/main.c
+++ b/uboot/common/main.c
@@ -501,8 +501,8 @@ void main_loop (void)
 	}
 
 	if (gpio_get_value(gpio_reset_btn) == GPIO_VAL_BTN_PRESSED) {
-		printf( "\nPress press RESET button for more than 5 seconds to run web failsafe mode\n\n" );
-		printf( "RESET button is pressed for: %2d second(s)", counter);
+		printf( "\nPress reset button for at least 5 seconds to enter web failsafe mode\n\n" );
+		printf( "Reset button held for: %2d second(s)", counter);
 	}
 	while (gpio_get_value(gpio_reset_btn) == GPIO_VAL_BTN_PRESSED) {
 
@@ -559,7 +559,7 @@ void main_loop (void)
 	
 	if (counter > 4) {
 	
-		printf( "\n\nRESET button was pressed for %d seconds\nHTTP server is starting for firmware update...\n\n", counter );
+		printf( "\n\nReset button was held for %d seconds\nHTTP server is starting for firmware update...\n\n", counter );
 	switch (gboard_param->machid) {
 	case MACH_TYPE_IPQ40XX_AP_DK04_1_C1:
 		gpio_set_value(GPIO_S1300_MESH_LED, 1);
@@ -581,7 +581,7 @@ void main_loop (void)
 		goto SKIPBOOT;
 
 	} else if ((counter <= 4) && (counter > 0)) {
-		printf( "\n\nCatution: RESET button wasn't pressed or not long enough!\nContinuing normal boot...\n\n" );
+		printf( "\n\nCaution: reset button wasn't held long enough!\nContinuing normal boot...\n\n" );
 	} else {
 	}
 	if(gboard_param->machid==MACH_TYPE_IPQ40XX_AP_DK01_1_C2)

--- a/uboot/drivers/gl/gl_ipq40xx_api.c
+++ b/uboot/drivers/gl/gl_ipq40xx_api.c
@@ -66,14 +66,14 @@ unsigned long hex2int(char *a, unsigned int len)
     return val;
 }
 
-/*convert a string,which length is 18, to a macaddress data type.*/    
+/* convert a string of length 18 to a macaddress data type. */
 #define MAC_LEN_IN_BYTE 6     
-#define COPY_STR2MAC(mac,str)  \ 	
-	int i, d = 2; \	   
-	do { \            
-		for(i = 0; i < MAC_LEN_IN_BYTE; i++) {\               
-			mac[i] = (a2x(str[i*d]) << 4) + a2x(str[i*d + 1]);\           
-		}\      
+#define COPY_STR2MAC(mac, str)  \
+	do { \
+		int i; \
+		for (i = 0; i < MAC_LEN_IN_BYTE; i++) { \
+			mac[i] = (a2x(str[i*2]) << 4) + a2x(str[i*2 + 1]); \
+		} \
 	} while(0)  
 
 void do_run_usage()
@@ -371,7 +371,7 @@ int upgrade(){
 			case MACH_TYPE_IPQ40XX_AP_DK04_1_C3:
 			case MACH_TYPE_IPQ40XX_AP_DK01_1_C1:
 				if(openwrt_firmware_size < hex2int(getenv("filesize"), strlen(getenv("filesize")))){
-					printf("Firmware oversize! Not flashing.\n");
+					printf("Firmware too large! Not flashing.\n");
 					return 0;
 				}
 				sprintf(cmd, "sf probe && sf erase 0x%x 0x%x && sf write 0x88000000 0x%x $filesize",
@@ -419,7 +419,7 @@ int do_run (cmd_tbl_t * cmdtp, int flag, int argc, char * const argv[])
 		sprintf(cmd, "tftpboot 0x88000000 %s", uboot_name);
 		if ( (ret = run_command(cmd, 0)) == GL_OK) {
 			if (TftpdownloadStatus != GL_OK) {
-				printf("%s failed. Please re-download\n", cmd);
+				printf("%s failed. Please re-download.\n", cmd);
 				return CMD_RET_FAILURE;
 			} else {
 				TftpdownloadStatus = -1;
@@ -438,7 +438,7 @@ int do_run (cmd_tbl_t * cmdtp, int flag, int argc, char * const argv[])
 		sprintf(cmd, "tftpboot 0x88000000 %s", openwrt_fw_name);
 		if ( (ret = run_command(cmd, 0)) == GL_OK) {
 			if (TftpdownloadStatus != GL_OK) {
-				printf("%s failed. Please re-download\n", cmd);
+				printf("%s failed. Please re-download.\n", cmd);
 				return CMD_RET_FAILURE;
 			} else {
 				TftpdownloadStatus = -1;
@@ -455,7 +455,7 @@ int do_run (cmd_tbl_t * cmdtp, int flag, int argc, char * const argv[])
 		sprintf(cmd, "tftpboot 0x88000000 %s", qsdk_fw_name);
 		if ( (ret = run_command(cmd, 0)) == GL_OK) {
 			if (TftpdownloadStatus != GL_OK) {
-				printf("%s failed. Please re-download\n", cmd);
+				printf("%s failed. Please re-download.\n", cmd);
 				return CMD_RET_FAILURE;
 			} else {
 				TftpdownloadStatus = -1;
@@ -499,7 +499,7 @@ int do_run (cmd_tbl_t * cmdtp, int flag, int argc, char * const argv[])
 	if (ret == GL_OK) {
 		printf("TFTP download and flash OK.\n");
 	} else {
-		printf("TFTP download Failed. Please re-download\n");
+		printf("TFTP download failed. Please re-download.\n");
 	}
 	gpio_set_value(g_gpio_power_led, !g_is_power_led_active_low);
 	LED_INIT();
@@ -548,7 +548,7 @@ int do_flash (cmd_tbl_t * cmdtp, int flag, int argc, char * const argv[])
 			}	
 		} else if (!strncmp(argv[1], "w", 1)) {
 			if (strlen(argv[3]) != 12) {
-				puts ("Error length ??? The length of the mac is 12.\n");
+				puts("Invalid mac address length\n");
 				return 1;
 			}
 			
@@ -590,7 +590,7 @@ int do_flash (cmd_tbl_t * cmdtp, int flag, int argc, char * const argv[])
 				*wifi_5g_checksum = checksum_5g;
 				*wifi_5g_9886_checksum = checksum_5g_9886;
 			}
-			puts ("Copy to Flash... ");
+			puts ("Copy to flash... ");
 			sprintf(cmd, "sf erase 0x%x 0x%x && sf write 0x88000100 0x%x 0x%x", 
 				CONFIG_ART_START, CONFIG_ART_SIZE, CONFIG_ART_START, CONFIG_ART_SIZE);
 			run_command(cmd, 0);
@@ -669,10 +669,10 @@ int find_calibration_data()
 	printf("Checking calibration status...\n");
 
 	if (*cal_2g_data == 0x2f20 && *cal_5g_data == 0x2f20 && (gboard_param->machid == MACH_TYPE_IPQ40XX_AP_DK04_1_C3 ? *cal_5g_9886_data == 0x2f20:1)) {
-		printf("Device have calibrated,checking test status...\n");
+		printf("Device is calibrated, checking test status...\n");
 		ret = 0;
 	} else {
-		printf("Device haven't calibrated,booting the calibration firmware...\n");
+		printf("Device isn't calibrated, booting the calibration firmware...\n");
 		ret = -1;
 	}
 	
@@ -736,10 +736,10 @@ int check_test()
 			*s0s==0x73 && *s1e==0x65 && *s2c==0x63 && *s3o==0x6f && \
 			*s4n==0x6e && *s5d==0x64 && *s6t==0x74 && *s7e==0x65 && \
 			*s8s==0x73 && *s9t==0x74) {
-		printf("Device haven tested, checking MAC info...\n");
+		printf("Device is tested, checking MAC info...\n");
 		ret = 0;
 	} else {
-		printf("Device haven't tested, please test device in calibration firmware...\n");
+		printf("Device isn't tested: please test device in calibration firmware...\n");
 		ret = -1;
 	}
 
@@ -766,7 +766,7 @@ int check_config()
 	}
 	//printf("eth0: %x:%x:%x:%x:%x:%x\n", addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]);
 	if (!memcmp(addr, addr_tmp, 6)) {
-		printf("Device don't have eth0 MAC info, please write MAC in calibration firmware...\n");
+		printf("Device doesn't have eth0 MAC info: please write MAC in calibration firmware...\n");
 		return -1;
 	}
 
@@ -777,7 +777,7 @@ int check_config()
 	}
 	//printf("eth1: %x:%x:%x:%x:%x:%x\n", addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]);
 	if (!memcmp(addr, addr_tmp, 6)) {
-		printf("Device don't have eth1 MAC info, please write MAC in calibration firmware...\n");
+		printf("Device doesn't have eth1 MAC info: please write MAC in calibration firmware...\n");
 		return -1;
 	}
 
@@ -788,7 +788,7 @@ int check_config()
 	}
 	//printf("2G: %x:%x:%x:%x:%x:%x\n", addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]);
 	if (!memcmp(addr, addr_tmp, 6)) {
-		printf("Device don't have 2G MAC info, please write MAC in calibration firmware...\n");
+		printf("Device doesn't have 2GHz MAC info: please write MAC in calibration firmware...\n");
 		return -1;
 	}
 
@@ -799,7 +799,7 @@ int check_config()
 	}
 	//printf("5G: %x:%x:%x:%x:%x:%x\n", addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]);
 	if (!memcmp(addr, addr_tmp, 6)) {
-		printf("Device don't have 5G MAC info, please write MAC in calibration firmware...\n");
+		printf("Device doesn't have 5GHz MAC info: please write MAC in calibration firmware...\n");
 		return -1;
 	}
 
@@ -811,11 +811,11 @@ int check_config()
 	}
 	//printf("5G: %x:%x:%x:%x:%x:%x\n", addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]);
 	if (!memcmp(addr, addr_tmp, 6)) {
-		printf("Device don't have 5G MAC info, please write MAC in calibration firmware...\n");
+		printf("Device doesn't have 5GHz MAC info: please write MAC in calibration firmware...\n");
 		return -1;
 	}
 	}
-	printf("Device have MAC info, starting firmware...\n\n");
+	printf("Device has MAC info, starting firmware...\n\n");
 	
 	return 0;
 }
@@ -836,7 +836,7 @@ int auto_update_by_tftp()
 
 	if (run_command(cmd, 0) == GL_OK) {
 		if (TftpdownloadStatus != GL_OK) {
-			printf("TFTP download firmware.bin failed. Please re-download\n");
+			printf("TFTP download of firmware.bin failed. Please re-download.\n");
 			return CMD_RET_FAILURE;
 		} else {
 			ret = upgrade();
@@ -846,7 +846,7 @@ int auto_update_by_tftp()
 
 	if (run_command(cmd1, 0) == GL_OK) {
 		if (TftpdownloadStatus != GL_OK) {
-			printf("TFTP download firmware.bin failed. Please re-download\n");
+			printf("TFTP download of firmware.bin failed. Please re-download.\n");
 			return CMD_RET_FAILURE;
 		} else {
 			ret = upgrade();

--- a/uboot/drivers/mmc/mmc.c
+++ b/uboot/drivers/mmc/mmc.c
@@ -347,7 +347,7 @@ mmc_berase(int dev_num, unsigned long start, lbaint_t blkcnt)
 		if (mmc->sec_feature_support & EXT_CSD_SEC_GB_CL_EN) {
 			arg = MMC_SECURE_TRIM1_ARG;
 		} else {
-			printf("\n\nCaution! Your devices Erase group is 0x%x\n"
+			printf("\n\nCaution! Your device's erase group is 0x%x\n"
 				"The erase range would be change to 0x%lx~0x%lx\n\n",
 				mmc->erase_grp_size, start & ~(mmc->erase_grp_size - 1),
 				((start + blkcnt + mmc->erase_grp_size)

--- a/uboot/drivers/usb/host/xhci.c
+++ b/uboot/drivers/usb/host/xhci.c
@@ -418,8 +418,7 @@ static int xhci_address_device(struct usb_device *udev)
 		ret = -EPROTO;
 		break;
 	case COMP_DEV_ERR:
-		puts("ERROR: Incompatible device"
-					"for address device command.\n");
+		puts("ERROR: incompatible device for address device command.\n");
 		ret = -ENODEV;
 		break;
 	case COMP_SUCCESS:

--- a/uboot/httpd/vendors/cleanwrt/404.html
+++ b/uboot/httpd/vendors/cleanwrt/404.html
@@ -10,6 +10,6 @@
 			<h1 class="red">PAGE NOT FOUND</h1>
 			<div class="i e">The page you were looking for doesn't exist!</div>
 		</div>
-		<div id="f">You can find more information about this project on <a href="https://github.com/pepe2k/u-boot_mod" target="_blank">GitHub</a></div>
+		<div id="f">You can find more information about this project on <a href="https://github.com/pepe2k/u-boot_mod" target="_blank">GitHub</a>.</div>
 	</body>
 </html>

--- a/uboot/httpd/vendors/cleanwrt/art.html
+++ b/uboot/httpd/vendors/cleanwrt/art.html
@@ -8,18 +8,17 @@
 	<body>
 		<div id="m">
 			<h1>ART UPDATE</h1>
-			<p>You are going to update <strong>ART (Atheros Radio Test)</strong> on the device.<br>Please, choose file from your local hard drive and click <strong>Update ART</strong> button.</p>
+			<p>You are going to update the <strong>ART (Atheros Radio Test) data</strong> on the device.<br>Please choose the file to upload then click the <strong>Update ART</strong> button.</p>
 			<form method="post" enctype="multipart/form-data"><input type="file" name="art"><input type="submit" value="Update ART"></form>
 			<div class="i w">
 				<strong>WARNINGS</strong>
 				<ul>
-					<li>do not power off the device during update</li>
-					<li>if everything goes well, the device will restart</li>
-					<li>you can upload whatever you want, so be sure that you choose proper ART image for your device</li>
+					<li>Do not power off the device during update.</li>
+					<li>If everything goes well, the device will restart.</li>
+					<li>There are no restrictions on uploaded files, so ensure the ART image is valid for your device.</li>
 				</ul>
 			</div>
 		</div>
-		<div id="f">You can find more information about this project on <a href="https://github.com/pepe2k/u-boot_mod" target="_blank">GitHub</a></div>
-        <div id="f">uboot2.0 version:20.05.22</div>
+		<div id="f">You can find more information about this project on <a href="https://github.com/pepe2k/u-boot_mod" target="_blank">GitHub</a>.</div>
 	</body>
 </html>

--- a/uboot/httpd/vendors/cleanwrt/fail.html
+++ b/uboot/httpd/vendors/cleanwrt/fail.html
@@ -8,8 +8,8 @@
 	<body>
 		<div id="m">
 			<h1 class="red">UPDATE FAILED</h1>
-			<div class="i e"><strong>Something went wrong during update</strong>Probably you have chosen wrong file (too big or too small) or you were trying to update ART on device with unknown FLASH type (and size) which is not allowed. Please, try again or contact with the author of this modification. You can also get more information during update in U-Boot console.</div>
+			<div class="i e"><strong>Something went wrong during the update.</strong> Perhaps you uploaded the wrong type of file (too big or too small) or you were trying to update ART on a device with unknown flash type/size, which is not supported. You can get more information during update on the U-Boot console.</div>
 		</div>
-		<div id="f">You can find more information about this project on <a href="https://github.com/pepe2k/u-boot_mod" target="_blank">GitHub</a></div>
+		<div id="f">You can find more information about this project on <a href="https://github.com/pepe2k/u-boot_mod" target="_blank">GitHub</a>.</div>
 	</body>
 </html>

--- a/uboot/httpd/vendors/cleanwrt/flashing.html
+++ b/uboot/httpd/vendors/cleanwrt/flashing.html
@@ -9,10 +9,9 @@
 	<body>
 		<div id="m">
 			<h1>UPDATE IN PROGRESS</h1>
-			<p>Your file was successfully uploaded! Update is in progress and you should wait for automatic reset of the device.<br>Update time depends on image size and may take up to a few minutes. You can close this page.</p>
+			<p>Your file was successfully uploaded. The update is now in progress and you should wait until the device automatically restarts. Depending on the image size, this may take a few minutes. You can safely close this page.</p>
 			<div id="l"></div>
 		</div>
-		<div id="f">You can find more information about this project on <a href="https://github.com/pepe2k/u-boot_mod" target="_blank">GitHub</a></div>
-        <div id="f">uboot2.0 version:20.05.14</div>
+		<div id="f">You can find more information about this project on <a href="https://github.com/pepe2k/u-boot_mod" target="_blank">GitHub</a>.</div>
 	</body>
 </html>

--- a/uboot/httpd/vendors/cleanwrt/index.html
+++ b/uboot/httpd/vendors/cleanwrt/index.html
@@ -8,18 +8,17 @@
 	<body>
 		<div id="m">
 			<h1>FIRMWARE UPDATE</h1>
-			<p>You are going to update <strong>firmware</strong> on the device.<br>Please, choose file from your local hard drive and click <strong>Update firmware</strong> button.</p>
+			<p>You are going to update the <strong>firmware</strong> on the device.<br>Please choose the file to upload then click the <strong>Update firmware</strong> button.</p>
 			<form method="post" enctype="multipart/form-data"><input type="file" name="firmware"><input type="submit" value="Update firmware"></form>
 			<div class="i w">
 				<strong>WARNINGS</strong>
 				<ul>
-					<li>do not power off the device during update</li>
-					<li>if everything goes well, the device will restart</li>
-					<li>you can upload whatever you want, so be sure that you choose proper firmware image for your device</li>
+					<li>Do not power off the device during update.</li>
+					<li>If everything goes well, the device will restart.</li>
+					<li>There are no restrictions on uploaded files, so ensure the firmware image is valid for your device.</li>
 				</ul>
 			</div>
 		</div>
-		<div id="f">You can find more information about this project on <a href="https://github.com/pepe2k/u-boot_mod" target="_blank">GitHub</a></div>
-        <div id="f">uboot2.0 version:20.05.22</div>
+		<div id="f">You can find more information about this project on <a href="https://github.com/pepe2k/u-boot_mod" target="_blank">GitHub</a>.</div>
 	</body>
 </html>

--- a/uboot/httpd/vendors/cleanwrt/uboot.html
+++ b/uboot/httpd/vendors/cleanwrt/uboot.html
@@ -8,19 +8,18 @@
 	<body>
 		<div id="m">
 			<h1>U-BOOT UPDATE</h1>
-			<p>You are going to update <strong>U-Boot bootloader</strong> on the device.<br>Please, choose file from your local hard drive and click <strong>Update U-Boot</strong> button.</p>
+			<p>You are going to update the <strong>U-Boot bootloader</strong> on the device.<br>Please choose the file to upload then click the <strong>Update U-Boot</strong> button.</p>
 			<form method="post" enctype="multipart/form-data"><input type="file" name="uboot"><input type="submit" value="Update U-Boot"></form>
 			<div class="i w">
 				<strong>WARNINGS</strong>
 				<ul>
-					<li>do not power off the device during update</li>
-					<li>if everything goes well, the device will restart</li>
-					<li>you can upload whatever you want, so be sure that you choose proper U-Boot image for your device</li>
-					<li>updating U-Boot is a very dangerous operation and may damage your device!</li>
+					<li>Do not power off the device during update.</li>
+					<li>If everything goes well, the device will restart.</li>
+					<li>There are no restrictions on uploaded files, so ensure the U-Boot image is valid for your device.</li>
+					<li>Updating U-Boot is a dangerous operation and may damage your device!</li>
 				</ul>
 			</div>
 		</div>
-		<div id="f">You can find more information about this project on <a href="https://github.com/pepe2k/u-boot_mod" target="_blank">GitHub</a></div>
-        <div id="f">uboot2.0 version:20.05.22</div>
+		<div id="f">You can find more information about this project on <a href="https://github.com/pepe2k/u-boot_mod" target="_blank">GitHub</a>.</div>
 	</body>
 </html>

--- a/uboot/httpd/vendors/makefsdatac
+++ b/uboot/httpd/vendors/makefsdatac
@@ -67,7 +67,7 @@ function print_data_array() {
 
 	# Content
 	if [ "$_file_ext" == "css"  ]; then
-		if [ -e "$yui_compressor" ]; then
+		if type -p java >/dev/null && [ -e "$yui_compressor" ]; then
 			_file_content=`java -jar "$yui_compressor" --charset utf-8 "$1" | od -A n -t x1 | tr -d '\r\n' | sed 's/ /0x/;s/ /, 0x/g;s/.\{102\}/&\n/g'`
 		else
 			_file_content=`cat "$1" | tr -d '\r\n\t' | od -A n -t x1 | tr -d '\r\n' | sed 's/ /0x/;s/ /, 0x/g;s/.\{102\}/&\n/g'`

--- a/uboot/net/httpd.c
+++ b/uboot/net/httpd.c
@@ -202,7 +202,7 @@ int do_http_upgrade( const ulong size, const int upgrade_type )
 		
 	} else if ( upgrade_type == WEBFAILSAFE_UPGRADE_TYPE_ART ) {
 
-		printf( "\n\n****************************\n*      ART  UPGRADING      *\n* DO NOT POWER OFF DEVICE! *\n****************************\n\n" );
+		printf( "\n\n****************************\n*      ART UPGRADING       *\n* DO NOT POWER OFF DEVICE! *\n****************************\n\n" );
 		sprintf(cmd, "sf probe && sf erase 0x170000 0x10000 && sf write 0x88000000 0x170000 0x10000");
 		run_command(cmd, 0);
 		return 0;
@@ -269,11 +269,11 @@ int do_http_progress( const int state )
 				/* LEDOFF(); */
 				udelay( 25000 );
 			}
-			printf( "HTTP ugrade is done! Rebooting...\n\n" );
+			printf( "HTTP upgrade is done! Rebooting...\n\n" );
 			break;
 
 		case WEBFAILSAFE_PROGRESS_UPGRADE_FAILED:
-			printf( "## Error: HTTP ugrade failed!\n\n" );
+			printf( "## Error: HTTP upgrade failed!\n\n" );
 
 			// blink LED fast for 4 sec
 			for ( i = 0; i < 80; ++i ) {


### PR DESCRIPTION
The first two patches of this pull request fix spelling mistakes, typos and other minor English issues in user-visible messages and HTML pages of your ipq40xx bootloader tree. They are entirely cosmetic and have no impact on functionality.

The third patch ensures the existing fallback path for compressing httpd .css files works when java is unavailable, as well as when yui_compressor is missing. It has no effect if the build machine does have a JVM available.